### PR TITLE
关闭用户自行注册帐套的功能，并增加相应的提示

### DIFF
--- a/src/main/java/cn/cerc/jmis/page/AppLoginPage.java
+++ b/src/main/java/cn/cerc/jmis/page/AppLoginPage.java
@@ -47,12 +47,6 @@ public class AppLoginPage extends AbstractJspPage implements IAppLogin {
 			if (form.logon())
 				return true;
 		} catch (Exception e) {
-			if (!e.getMessage().contains("</a>")) {
-				if (password == null || "".equals(password)) {
-					getResponse().sendRedirect("TFrmEasyReg?phone=" + userCode);
-					return false;
-				}
-			}
 			this.add("loginMsg", e.getMessage());
 		}
 		this.execute();
@@ -71,6 +65,7 @@ public class AppLoginPage extends AbstractJspPage implements IAppLogin {
 		req.setAttribute("userCode", userCode);
 		req.setAttribute("password", password);
 		req.setAttribute("needVerify", "false");
+
 		// 如长度大于10表示用手机号码登入
 		if (userCode.length() > 10) {
 			String oldCode = userCode;
@@ -86,6 +81,7 @@ public class AppLoginPage extends AbstractJspPage implements IAppLogin {
 			app = new LocalService((AbstractForm) form);
 		else
 			app = new LocalService(form.getHandle());
+
 		app.setService("SvrUserLogin.check");
 		String IP = getIPAddress();
 		if (app.exec("Account_", userCode, "Password_", password, "MachineID_", deviceId, "ClientIP_", IP)) {
@@ -119,7 +115,6 @@ public class AppLoginPage extends AbstractJspPage implements IAppLogin {
 	 * 根据电话号码返回用户帐号，用于普及版登入
 	 * 
 	 * @param tel
-	 * @return
 	 * @throws IOException
 	 * @throws ServletException
 	 */

--- a/src/main/java/cn/cerc/jmis/services/SvrUserLogin.java
+++ b/src/main/java/cn/cerc/jmis/services/SvrUserLogin.java
@@ -68,12 +68,14 @@ public class SvrUserLogin extends CustomService {
 		String userCode = headIn.getSafeString("Account_");
 		if (userCode.equals(""))
 			throw new SecurityCheckException("用户帐号不允许为空！");
+
 		SqlQuery dsUser = new SqlQuery(this);
 		dsUser.setCommandText(
 				String.format("select CorpNo_,ID_,Code_,Name_,Mobile_,DeptCode_,Enabled_,Password_,BelongAccount_,"
 						+ "Encrypt_,SecurityLevel_,SecurityMachine_,PCMachine1_,PCMachine2_,PCMachine3_,RoleCode_,DiyRole_ "
 						+ "from %s where Code_='%s'", SystemTable.get(SystemTable.getUserInfo), userCode));
 		dsUser.open();
+
 		if (dsUser.eof())
 			throw new SecurityCheckException(String.format("该帐号(%s)并不存在，禁止登录！", userCode));
 		if (dsUser.getInt("Enabled_") < 1)
@@ -230,10 +232,11 @@ public class SvrUserLogin extends CustomService {
 		String userCode = headIn.getSafeString("UserCode_");
 
 		Record headOut = getDataOut().getHead();
-		if (userCode.equals("")) {
+		if ("".equals(userCode)) {
 			headOut.setField("Msg_", "手机号不允许为空！");
 			return false;
 		}
+
 		SqlQuery ds = new SqlQuery(this);
 		String sql = String.format("a.Mobile_='%s' and ((a.BelongAccount_ is null) or (a.BelongAccount_=''))",
 				userCode);
@@ -246,6 +249,7 @@ public class SvrUserLogin extends CustomService {
 			headOut.setField("Msg_", "没有找到您的手机号！");
 			return false;
 		}
+
 		if (ds.size() != 1) {
 			headOut.setField("Msg_",
 					String.format(
@@ -490,7 +494,7 @@ public class SvrUserLogin extends CustomService {
 		rs.setField("Account_", getUserCode());
 		rs.setField("LoginID_", this.getProperty("ID"));
 		rs.setField("Computer_", computer);
-		rs.setField("clientIP_", (String) this.getProperty(Application.clientIP));
+		rs.setField("clientIP_", this.getProperty(Application.clientIP));
 		rs.setField("LoginTime_", TDateTime.Now());
 		rs.setField("ParamValue_", handle.getCorpNo());
 		rs.setField("KeyCardID_", GuidNull);

--- a/src/main/java/cn/cerc/jmis/services/SvrUserLogin.java
+++ b/src/main/java/cn/cerc/jmis/services/SvrUserLogin.java
@@ -246,7 +246,7 @@ public class SvrUserLogin extends CustomService {
 		ds.add("where (%s)", sql);
 		ds.open();
 		if (ds.size() == 0) {
-			headOut.setField("Msg_", "没有找到您的手机号！");
+			headOut.setField("Msg_", "您的手机号码不存在于系统中，如果您需要注册帐号，请 <a href='TFrmContact'>联系客服</a> 进行咨询");
 			return false;
 		}
 


### PR DESCRIPTION
close [#5325](https://github.com/mimrc/vine2015/issues/5325)

帐号注册、登录分析

1、输入帐号 + 密码
```
根据现有的帐号 + 密码进行认证
     通过  进入系统

     未通过 无法进入，并增加提示
```

2、仅输入帐号 
```
     帐号存在系统中且手机号码不为空，跳转到登录页面

     帐号存在，但没有绑定密码，提示仅允许使用 帐号 + 密码登录

     帐号不存在，直接提示帐号不存在
```

**注意：若帐号长度大于10，则判定为手机号码**

3、输入手机号 + 密码
```
手机号码绑定多个帐号，添加提示只能通过帐号密码登录

手机号码有且只有绑定一个帐号

手机号对应的帐号存在，帐号 + 密码 通过，进入系统

手机号对应的帐号存在，帐号 + 密码 不一致，无法进入，提示错误

手机号码不存在，直接提示不存在
```

4、仅输入手机号
```
手机号码绑定多个帐号，添加提示只能通过帐号密码登录

手机号码有且只有绑定一个帐号

    手机号码对应的帐号存在，跳转到发送验证码页面

   手机号码不存在，跳转到注册页面进行注册   
       改成 
   手机号码不存在，直接提示不存在
```

